### PR TITLE
fixed adventure delete and residual review trickledown issue.

### DIFF
--- a/controllers/adventureController.js
+++ b/controllers/adventureController.js
@@ -73,5 +73,8 @@ module.exports = {
         db.Community.deleteMany({ adventureId: req.params.id })
             .then(() => res.status(204).end())
             .catch(err => res.status(500).json(err));
+        db.Review.deleteMany({ adventureId: req.params.id })
+            .then(() => res.status(204).end())
+            .catch(err => res.status(500).json(err));
     }
 }


### PR DESCRIPTION
when adventure was deleted, reviews left about that adventure were causing the app to break. Now, deleting adventure also deletes reviews left about that adventure.